### PR TITLE
Nissix plugin scope-packages on isolated-vm-poc

### DIFF
--- a/avi-worker.js
+++ b/avi-worker.js
@@ -1,5 +1,5 @@
 const fs = require('fs')
-const {WebWorker} = require('node-webworker')
+const {WebWorker} = require('@wix/node-webworker')
 const fetch = require('node-fetch')
 
 const snapshotPromise = (async () => {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "lodash": "^4.17.15",
     "mathjs": "^6.5.0",
     "node-fetch": "^2.6.0",
-    "node-webworker": "^0.3.712"
+    "@wix/node-webworker": "^0.3.712"
   },
   "devDependencies": {
     "nock": "^11.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,17 @@
 # yarn lockfile v1
 
 
+"@wix/node-webworker@^0.3.712":
+  version "0.3.917"
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@wix/node-webworker/-/@wix/node-webworker-0.3.917.tgz#7c4b3878eae4be37ad5fdd54fd3b7448e7f25826"
+  integrity sha1-fEs4eOrkvjetX91U/Tt0SOfyWCY=
+  dependencies:
+    nan "^2.14.0"
+    node-fetch "^1.6.3"
+    node-gyp "^6.0.0"
+    resolve "^1.3.3"
+    segfault-handler "^1.3.0"
+
 abbrev@1:
   version "1.1.1"
   resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
@@ -528,17 +539,6 @@ node-gyp@^6.0.0:
     semver "^5.7.1"
     tar "^4.4.12"
     which "^1.3.1"
-
-node-webworker@^0.3.712:
-  version "0.3.712"
-  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/node-webworker/-/node-webworker-0.3.712.tgz#ee66d1cbb3e43480fc18b662f568e5c023a0250c"
-  integrity sha1-7mbRy7PkNID8GLZi9WjlwCOgJQw=
-  dependencies:
-    nan "^2.14.0"
-    node-fetch "^1.6.3"
-    node-gyp "^6.0.0"
-    resolve "^1.3.3"
-    segfault-handler "^1.3.0"
 
 nopt@^4.0.1:
   version "4.0.1"


### PR DESCRIPTION
Hi, I'm Nissix, the automated PR bot!

Wix is moving its internal packages to the @wix scope (but still in the internal registry). Publishing new unscoped internal packages is no longer allowed, and all existing packages are moving to @wix. This means changing package names, and also all usages of those packages to their @wix scope version.

This PR is an automatic codemod that moves all of your packages to @wix scope, and changes any usages (`pacakge.json`, imports, requires, etc..) to their @wix version.

| :bangbang: | This codemod is best-effort! Meaning it may not have found and fixed all usages, but it did change your package.jsons. So go over the changes carefully and test this version carefully  |
| :--------: | :----------------------------------------------------------------------------------------------------- |

If you want to know why we don't support publishing unscoped to the internal registry, check out this article on [Dependency Confusion](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610)

If you are unsure, need help or have questions, reach us at #wix-scope-migration

Error Log:
npx: installed 234 in 10.836s
warning package.json: No license field
warning isolated-vm-poc@1.0.0: No license field



Output Log:
Migrating package "isolated-vm-poc" in .


## Migration from non scope to @wix/scoped packages
> /tmp/4d29fbd6c10ff2100f92955380a8fc16

#### rename package.json dependencies/dev/bundled/peer/optional, jest & eslintConfig
```
package.json
```

#### replace import/require in js/ts files
```
avi-worker.js
```
yarn install v1.22.5
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Building fresh packages...
success Saved lockfile.
Done in 55.97s.

